### PR TITLE
[fix] ポケモン取得タイミング調整

### DIFF
--- a/src/pages/components/Quiz.jsx
+++ b/src/pages/components/Quiz.jsx
@@ -2,12 +2,15 @@ import { useEffect, useState } from "react"
 import { Button, Image } from "@mantine/core"
 
 const Quiz = () => {
+  const [start, setStart] = useState(false)
   const [pokemon, setPokemon] = useState({})
+  const [nextPokemon, setNextPokemon] = useState({})
   const [nameJa, setNameJa] = useState()
-  const [show, setShow] = useState(true)
+  const [nextNameJa, setNextNameJa] = useState()
+  const [showName, setShowName] = useState(false)
 
-  const getPokemon = async () => {
-    setShow(false)
+  // あらかじめ取得しておくポケモン
+  const getNextPokemon = async () => {
     fetch("https://pokeapi.co/api/v2/pokemon?offset=0&limit=1118")
       .then((res) => res.json())
       .then((data) => {
@@ -17,47 +20,65 @@ const Quiz = () => {
       })
       .then((res) => res.json())
       .then((data) => {
-        setPokemon(data)
+        setNextPokemon(data)
         return fetch(data.species.url)
       })
       .then((res) => res.json())
       .then((data) => {
-        setNameJa(data.names[0].name)
+        setNextNameJa(data.names[0].name)
       })
+  }
+
+  useEffect(async () => {
+    await getNextPokemon()
+  }, [])
+
+  const startQuiz = () => {
+    setPokemon(nextPokemon)
+    setNameJa(nextNameJa)
+    setStart(true)
+  }
+
+  const answer = async () => {
+    setNameJa(nextNameJa)
+    setShowName(true)
+    await getNextPokemon()
+  }
+
+  const nextGame = () => {
+    setPokemon(nextPokemon)
+    setShowName(false)
   }
 
   return (
     <div className='w-[100%] max-w-[700px] mx-auto pt-4'>
-      {pokemon.name && (
-        <div className='w-[50%] mx-auto'>
-          <Image src={pokemon.sprites.front_default} alt={pokemon.name} />
-          {show ? (
-            <h3 className='text-center text-[24px] m-0'>{nameJa}</h3>
-          ) : (
-            <h3 className='text-center text-[24px] m-0'>???</h3>
-          )}
+      {start ? (
+        <div>
+          <div className='w-[50%] mx-auto'>
+            {pokemon && <Image src={pokemon.sprites.front_default} alt={pokemon.name} />}
+            {showName ? (
+              <h3 className='text-center text-[24px] m-0'>{nameJa}</h3>
+            ) : (
+              <h3 className='text-center text-[24px] m-0'>???</h3>
+            )}
+          </div>
+          <div className='flex gap-2 mt-4'>
+            {!showName ? (
+              <Button color='red' onClick={() => answer()} className='w-[100%] mb-3' size='md'>
+                答え
+              </Button>
+            ) : (
+              <Button color='cyan' onClick={() => nextGame()} className='w-[100%]' size='md'>
+                問題
+              </Button>
+            )}
+          </div>
         </div>
-      )}
-      <div className='flex gap-2 mt-4'>
-        <Button
-          color='cyan'
-          onClick={getPokemon}
-          className='w-[100%]'
-          size='md'
-        >
-          Quiz!!
+      ) : (
+        <Button color='cyan' onClick={() => startQuiz()} className='w-[100%]' size='md'>
+          問題
         </Button>
-        {!show && (
-          <Button
-            color='red'
-            onClick={() => setShow(true)}
-            className='w-[100%] mb-3'
-            size='md'
-          >
-            答え
-          </Button>
-        )}
-      </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## やったこと
- 初回レンダリング時に1問目に表示するポケモンを取得、state に代入しておく
- クイズスタートのタイミングで取得していたポケモン問題の表示
- 答え合わせのボタン押下時に名前の表示と次の問題のポケモンを取得しておく
- 次の問題ボタン押下時、取得していたポケモンを入れ替えるようにして表示

## つまずいたポイント
- React のレンダリングされるのは、変数などが親の変数なりの状態が変わったタイミングで子コンポーネントもレンダリングされる（PR にコメント済み）